### PR TITLE
Fixed log to get it working on hardware

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -14,10 +14,14 @@ board = esp32dev
 framework = arduino
 monitor_speed = 115200
 monitor_flags = --raw
+build_flags = -Wall -std=c++11 -DCONFIG_ARDUHAL_LOG_COLORS
+monitor_dtr = 0
+monitor_rts = 0
 
 [env:myrelease]
-build_flags = -Wall -D NDEBUG -O3 -std=c++11
+build_type = release
+build_flags = ${env.build_flags} -DNDEBUG -O3 -DCORE_DEBUG_LEVEL=3 
 
 [env:mydebug]
 build_type = debug
-build_flags = -Wall -O2 -std=c++11
+build_flags = ${env.build_flags} -O2 -DCORE_DEBUG_LEVEL=5

--- a/src/fullnessTask.cpp
+++ b/src/fullnessTask.cpp
@@ -5,7 +5,7 @@ using namespace Zotbins;
 
 static const char *name = "fullnessTask";
 static const int priority = 1;
-static const uint32_t stackSize = 1024;
+static const uint32_t stackSize = 4096;
 
 FullnessTask::FullnessTask()
     : Task(name, priority, stackSize)
@@ -32,5 +32,7 @@ void FullnessTask::loop()
 {
     while (1)
     {
+        vTaskDelay(1000 / portTICK_PERIOD_MS); // Delay for 1000 ms
+        log_i("Hello from Fullness Task");
     }
 }

--- a/src/usageTask.cpp
+++ b/src/usageTask.cpp
@@ -1,10 +1,11 @@
 #include "usageTask.hpp"
+#include <Arduino.h>
 
 using namespace Zotbins;
 
 static const char *name = "usageTask";
 static const int priority = 1;
-static const uint32_t stackSize = 1024;
+static const uint32_t stackSize = 4096;
 
 UsageTask::UsageTask()
     : Task(name, priority, stackSize)
@@ -31,5 +32,7 @@ void UsageTask::loop()
 {
     while (1)
     {
+        vTaskDelay(1000 / portTICK_PERIOD_MS); // Delay for 1000 msn
+        log_i("Hello from Usage Task");
     }
 }

--- a/src/weightTask.cpp
+++ b/src/weightTask.cpp
@@ -1,10 +1,11 @@
 #include "weightTask.hpp"
+#include <Arduino.h>
 
 using namespace Zotbins;
 
 static const char *name = "weightTask";
 static const int priority = 1;
-static const uint32_t stackSize = 1024;
+static const uint32_t stackSize = 4096;
 
 WeightTask::WeightTask()
     : Task(name, priority, stackSize)
@@ -31,5 +32,7 @@ void WeightTask::loop()
 {
     while (1)
     {
+        vTaskDelay(1000 / portTICK_PERIOD_MS); // Delay for 1000 ms
+        log_i("Hello from Weight Task");
     }
 }


### PR DESCRIPTION
## Description

Logging did not work on the ESP-32. The tasks' stack sizes were too small and the tasks had a stack overflow. In addition, colors were disabled and the user could not read from the serial monitor.

Disabled DTS & RTS, increased the stack size from 1024 to 4096, and changed the build flags to enable color.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code improvement (a non-breaking change that improves the quality of the code)
- [ ] Documentation Change (update to the documentation with no changes to the code)

## Testing and Verification Instructions

1. Compile the code with the new changes
2. Verify that the logs appear in color

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
