### PR TITLE
Fixed default env bug & platform version compilation bug

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -8,16 +8,25 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
-[env]
+[platformio]
+default_envs = mydebug
+
+[esp32dev]
 platform = espressif32
 board = esp32dev
 framework = arduino
+build_flags = -Wall -std=c++11 -DCONFIG_ARDUHAL_LOG_COLORS
 monitor_speed = 115200
 monitor_flags = --raw
+monitor_dtr = 0
+monitor_rts = 0
 
 [env:myrelease]
-build_flags = -Wall -D NDEBUG -O3 -std=c++11
+extends = esp32dev
+build_type = release
+build_flags = ${esp32dev.build_flags} -DNDEBUG -O3 -DCORE_DEBUG_LEVEL=3
 
 [env:mydebug]
+extends = esp32dev
 build_type = debug
-build_flags = -Wall -O2 -std=c++11
+build_flags = ${esp32dev.build_flags} -O2 -DCORE_DEBUG_LEVEL=5

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@
 default_envs = mydebug
 
 [esp32dev]
-platform = espressif32
+platform = espressif32 @ ~3.5.0
 board = esp32dev
 framework = arduino
 build_flags = -Wall -std=c++11 -DCONFIG_ARDUHAL_LOG_COLORS


### PR DESCRIPTION
## Description

Previously, the default env would build both debug & release environments. Now, the default env only builds the debug environment.

In addition, there was a bug where a header was not found in `espressif32 @ ~4.1.0`. Reverted platform version to `espressif32 @ ~3.5.0` which functions properly.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code improvement (a non-breaking change that improves the quality of the code)
- [ ] Documentation Change (update to the documentation with no changes to the code)

## Testing and Verification Instructions

1. Build using the default environment
2. Verify that the build compiles successfully and that only the debug environment is built

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
