### PR TITLE
Added WiFi task

### DIFF
--- a/include/wifiTask.hpp
+++ b/include/wifiTask.hpp
@@ -1,0 +1,52 @@
+#ifndef WIFI_TASK_HPP
+#define WIFI_TASK_HPP
+
+#include "task.hpp"
+
+namespace Zotbins
+{
+    class WiFiTask : public Task
+    {
+    public:
+        WiFiTask();
+
+        /**
+         * @brief Start execution of WiFi Task
+         *
+         */
+        void start() override;
+
+    private:
+        /**
+         * @brief Function to be called by FreeRTOS function xTaskCreate().
+         * Calls setup() and loop()
+         *
+         * @param task WiFi Task object casted as void pointer
+         */
+        static void taskFunction(void *task);
+
+        /**
+         * @brief Setup WiFi Task before looping forever.
+         * This function should not be called outside of taskFunction()
+         *
+         */
+        void setup();
+
+        /**
+         * @brief Loop inside of WiFi Task.
+         * This function should not be called outside of taskFunction().
+         *
+         */
+        void loop();
+
+        /**
+         * @brief Connect to WiFi for first time
+         *
+         * @return true/false if successfully connected to WiFi or not
+         */
+        bool setupWifi();
+    };
+
+}
+
+#endif

--- a/include/wifiTask.hpp
+++ b/include/wifiTask.hpp
@@ -8,6 +8,10 @@ namespace Zotbins
     class WiFiTask : public Task
     {
     public:
+        /**
+         * @brief Construct a new Wi Fi Task object
+         *
+         */
         WiFiTask();
 
         /**

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,8 +2,10 @@
 #include "fullnessTask.hpp"
 #include "usageTask.hpp"
 #include "weightTask.hpp"
+#include "wifiTask.hpp"
 
 #define ZBIN_CORE_VERSION "0.0.1"
+#define ZBIN_DISABLE_WIFI
 
 void setup()
 {
@@ -13,12 +15,19 @@ void setup()
     Zotbins::FullnessTask fullnessTask;
     Zotbins::UsageTask usageTask;
     Zotbins::WeightTask weightTask;
+    #ifndef ZBIN_DISABLE_WIFI
+    Zotbins::WiFiTask wifiTask;
+    #endif
+
     // TODO: Create task for MQTT
 
     // Start all tasks
     fullnessTask.start();
     usageTask.start();
     weightTask.start();
+    #ifndef ZBIN_DISABLE_WIFI
+    wifiTask.start();
+    #endif
 }
 
 void loop()

--- a/src/wifiTask.cpp
+++ b/src/wifiTask.cpp
@@ -1,0 +1,84 @@
+#include "wifiTask.hpp"
+
+#include <Arduino.h>
+#include <WiFi.h>
+
+using namespace Zotbins;
+
+// TODO: Move config to separate header file
+namespace WiFiConfig
+{
+    const char *ssid = "";
+    const char *pwd = "";
+}
+
+static const char *name = "WiFiTask";
+static const int priority = 1;
+static const uint32_t stackSize = 4096;
+
+WiFiTask::WiFiTask()
+    : Task(name, priority, stackSize)
+{
+}
+
+void WiFiTask::start()
+{
+    xTaskCreate(taskFunction, mName, mStackSize, this, mPriority, nullptr);
+}
+
+void WiFiTask::taskFunction(void *task)
+{
+    WiFiTask *wifiTask = static_cast<WiFiTask *>(task);
+    wifiTask->setup();
+    wifiTask->loop();
+}
+
+void WiFiTask::setup()
+{
+    if (setupWifi())
+    {
+        log_i("WiFi Connected to %s", WiFiConfig::ssid);
+    }
+    else
+    {
+        while (1)
+        {
+            log_e("Cannot connect to WiFi");
+            vTaskDelay(10000 / portTICK_PERIOD_MS);
+        }
+    }
+}
+
+void WiFiTask::loop()
+{
+    while (1)
+    {
+        vTaskDelay(1000 / portTICK_PERIOD_MS); // Delay for 1000 milliseconds
+        log_i("Hello from WiFi Task");
+    }
+}
+
+bool WiFiTask::setupWifi()
+{
+    const uint32_t MAX_WIFI_CONNECT_COUNT = 100;
+    uint32_t wifiConnectCount = 0;
+
+    WiFi.mode(WIFI_STA);
+    WiFi.begin(WiFiConfig::ssid, WiFiConfig::pwd);
+
+    while (!WiFi.isConnected())
+    {
+        if (wifiConnectCount < MAX_WIFI_CONNECT_COUNT)
+        {
+            log_d("Attempting to connect to WiFi...");
+            ++wifiConnectCount;
+        }
+        else
+        {
+            return false;
+        }
+
+        vTaskDelay(1000 / portTICK_PERIOD_MS); // Delay for 1 second
+    }
+    return true;
+}


### PR DESCRIPTION
## Description

Created WiFi task to connect to WiFi. For now, the WiFi task has been disabled with the `ZBIN_DISABLE_WIFI` macro to not interfere with the rest of the development. 

The WiFi task works as intended and connects to WiFi. However, you must manually change the credentials in `WifiTask.cpp` at `WifiConfig::ssid` and `WiFiConfig::pwd`. This may not work on UCI WiFi due to the requirement to manually sign in.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code improvement (a non-breaking change that improves the quality of the code)
- [ ] Documentation Change (update to the documentation with no changes to the code)

## Testing and Verification Instructions

1. Compile the code with the new changes.
2. Remove the `ZBIN_DISABLE_WIFI` macro.
3. Add your WiFi credentials at WifiConfig::ssid and WifiConfig::pwd.
4. Upload the code onto the ESP-32.
5. Verify that you see a log stating that the ESP-32 is connected to WiFi. 

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
