### PR TITLE
Exclude Doxygen extensions from Github Language List

### DIFF
--- a/.doxygen/extensions/nice.py
+++ b/.doxygen/extensions/nice.py
@@ -1,0 +1,1 @@
+print("AJDSLKD")

--- a/.doxygen/extensions/nice.py
+++ b/.doxygen/extensions/nice.py
@@ -1,1 +1,0 @@
-print("AJDSLKD")

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.doxygen/extensions/* linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+.doxygen/extensions/* linguist-vendored
+

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-.doxygen/extensions/* linguist-vendored


### PR DESCRIPTION
## Description

HTML, CSS, and Javascript are listed as the primary languages for this repo because of the Doxygen extensions. Removed these languages using `.gitattributes`, so it only mentions C++. (Ignore the random commits, I didn't realize that the language list only applies to the `main` branch)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code improvement (a non-breaking change that improves the quality of the code)
- [ ] Documentation Change (update to the documentation with no changes to the code)

## Testing and Verification Instructions

1. Merge the PR to main
2. Verify that HTML, CSS, and JS is removed from the language list

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
