### PR TITLE
Task Notifications Interrupts

### DIFF
--- a/components/TaskComponent/weightTask.cpp
+++ b/components/TaskComponent/weightTask.cpp
@@ -8,6 +8,7 @@ using namespace Zotbins;
 
 const gpio_num_t PIN_DOUT = GPIO_NUM_2;
 const gpio_num_t PIN_PD_SCK = GPIO_NUM_14;
+static TaskHandle_t xTaskToNotify = NULL;
 
 const gpio_config_t PIN_DOUT_CONFIG = {
     .pin_bit_mask = 0x00000004,
@@ -26,6 +27,7 @@ const gpio_config_t PIN_PD_SCK_CONFIG = {
 static const char *name = "weightTask";
 static const int priority = 1;
 static const uint32_t stackSize = 4096;
+static const int core = 1;
 
 WeightTask::WeightTask(QueueHandle_t &messageQueue)
     : Task(name, priority, stackSize), mMessageQueue(messageQueue)
@@ -34,7 +36,7 @@ WeightTask::WeightTask(QueueHandle_t &messageQueue)
 
 void WeightTask::start()
 {
-    xTaskCreate(taskFunction, mName, mStackSize, this, mPriority, nullptr);
+    xTaskCreatePinnedToCore(taskFunction, mName, mStackSize, this, mPriority, &xTaskToNotify, core);
 }
 
 void WeightTask::taskFunction(void *task)
@@ -171,6 +173,7 @@ void WeightTask::loop()
 
     while (1)
     {
+        ulTaskNotifyTake(pdTRUE, (TickType_t)portMAX_DELAY);
         gpio_set_level(wm.pd_sck, 0);
         hx711_is_ready(&wm, &ready);
         if (ready)
@@ -189,5 +192,7 @@ void WeightTask::loop()
 
         vTaskDelay(1000 / portTICK_PERIOD_MS); // Delay for 1000 milliseconds
         ESP_LOGI(name, "Hello from Weight Task : %f", (weight));
+        xTaskToNotify = xTaskGetHandle("usageTask");
+        vTaskResume(xTaskToNotify);
     }
 }

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -26,23 +26,16 @@ extern "C" void app_main(void)
     QueueHandle_t messageQueue = xQueueCreate(messageQueueSize, sizeof(Zotbins::Message));
     assert(messageQueue != nullptr);
 
-    // Zotbins::WeightTask weightTask(messageQueue);
-    // weightTask.start();
-    // Zotbins::UsageTask usageTask(messageQueue);
-
-    Zotbins::CameraTask cameraTask(messageQueue);
+    //Zotbins::CameraTask cameraTask(messageQueue);
     // usageTask.start();
-    cameraTask.start();
-
+    //cameraTask.start();
+    Zotbins::WeightTask weightTask(messageQueue);
+    weightTask.start();
+    Zotbins::FullnessTask fullnessTask(messageQueue);
+    fullnessTask.start();
     Zotbins::UsageTask usageTask(messageQueue);
     usageTask.start();
 
-    Zotbins::FullnessTask fullnessTask(messageQueue);
-    fullnessTask.start();
-
-    Zotbins::ServoTask servoTask(messageQueue);
-    servoTask.start();
-
-    Zotbins::WeightTask weightTask(messageQueue);
-    weightTask.start();
+    // Zotbins::ServoTask servoTask(messageQueue);
+    // servoTask.start();
 }


### PR DESCRIPTION
Two logic states:
(1) currently nothing is detected and previously nothing was detected by breakbeam

no trash has entered the bin
remain in usageTask and do not interrupt to notify fullnessTask ESP_LOGI(name, "Nothing detected");
(2a) currently detecting by breakbeam

trash is being placed into the bin
remain in usageTask and still do not interrupt to notify fullnessTask stay in while loop until no longer detecting
ESP_LOGI(name, "Detecting item");
(2b) currently nothing is detected and previously was detected by breakbeam trash has entered the bin and closed
ESP_LOGI(name, "No longer detected");
interrupt to notify fullnessTask
removing if (detect == 0) will disrupt the logic above and instead interrupt every time nothing is being detected. Rather then interrupting based on if a user opened the bin, threw their trash, and closed the bin to then interrupt to check fullness/weight of the item that has entered.

please feel free to suggest changes to better make this logic more clear to others that may look at this code as well

## Description

Please write description of change

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code improvement (a non-breaking change that improves the quality of the code)
- [ ] Documentation Change (update to the documentation with no changes to the code)

## Testing and Verification Instructions

1. Step 1
2. Step 2

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
