### PR TITLE
Feature/restart

### DIFF
--- a/components/peripherals/peripheral_manager/CMakeLists.txt
+++ b/components/peripherals/peripheral_manager/CMakeLists.txt
@@ -1,4 +1,4 @@
-idf_component_register(SRCS "peripheral_manager.cpp"
+idf_component_register(SRCS "peripheral_manager.cpp" "restart.c"
                        INCLUDE_DIRS "include"
                        REQUIRES log freertos
                        PRIV_REQUIRES peripheral_interface peripheral_queue publish)

--- a/components/peripherals/peripheral_manager/include/restart.hpp
+++ b/components/peripherals/peripheral_manager/include/restart.hpp
@@ -1,0 +1,40 @@
+#ifndef RESTART_HPP
+#define RESTART_HPP
+#include "freertos/FreeRTOS.h" 
+#include "freertos/event_groups.h"
+#include "esp_err.h"
+#include "esp_system.h"
+#include "esp_system.h"
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern EventGroupHandle_t restartGroup;
+
+
+#define SYSTEM_FLAG  (1 << 0)
+#define SERVER_FLAG  (1 << 0)
+/**
+ * @breif Restart Task waits for two bits to be set (Server Bit and System Bit) before Restarting ESP32
+ */
+void restartTask(EventGroupHandle_t restartGroup);
+/**
+ * @breif Sets System Bit
+ */
+void updateRestart(int requirement, EventGroupHandle_t restartGroup);
+/**
+ * Sends message to server and restarts ESP32
+ */
+void restart();
+/**
+ * Sets Server Bit
+ */
+void receiveServer(EventGroupHandle_t restartGroup);
+
+#ifdef __cplusplus
+} 
+#endif
+
+#endif

--- a/components/peripherals/peripheral_manager/peripheral_manager.cpp
+++ b/components/peripherals/peripheral_manager/peripheral_manager.cpp
@@ -65,7 +65,7 @@ static void run_manager(void *arg)
 
     while (1)
     {
-        updateRestart(0,restartGroup);
+        
         xEventGroupWaitBits(manager_eg, USAGE_EVENT_BIT, pdTRUE, pdTRUE, portMAX_DELAY); // Wait for the breakbeam to be tripped, then collect sensor data.
         updateRestart(1,restartGroup);
         xEventGroupSetBits(manager_eg, MANAGER_STATUS_EVENT_BIT); // Indicate that the peripheral manager is running
@@ -92,6 +92,7 @@ static void run_manager(void *arg)
         // Publish data
         publish_payload(fullness, weight, usage);
         xEventGroupClearBits(manager_eg, MANAGER_STATUS_EVENT_BIT); // Indicate that the peripheral manager is stopped
+        updateRestart(0,restartGroup);
     }
 }
 

--- a/components/peripherals/peripheral_manager/peripheral_manager.cpp
+++ b/components/peripherals/peripheral_manager/peripheral_manager.cpp
@@ -65,7 +65,7 @@ static void run_manager(void *arg)
     while (1)
     {
         xEventGroupWaitBits(manager_eg, USAGE_EVENT_BIT, pdTRUE, pdTRUE, portMAX_DELAY); // Wait for the breakbeam to be tripped, then collect sensor data.
-
+         
         xEventGroupSetBits(manager_eg, MANAGER_STATUS_EVENT_BIT); // Indicate that the peripheral manager is running
 
         // Collect sensor data---add additional sensors here as needed

--- a/components/peripherals/peripheral_manager/peripheral_manager.cpp
+++ b/components/peripherals/peripheral_manager/peripheral_manager.cpp
@@ -18,6 +18,7 @@
 
 #include "peripheral_manager.hpp"
 #include "client_publish.hpp"
+#include "restart.hpp"
 #include "esp_log.h"
 #include "serialize.hpp"
 #include "events.hpp"
@@ -64,8 +65,9 @@ static void run_manager(void *arg)
 
     while (1)
     {
+        updateRestart(0,restartGroup);
         xEventGroupWaitBits(manager_eg, USAGE_EVENT_BIT, pdTRUE, pdTRUE, portMAX_DELAY); // Wait for the breakbeam to be tripped, then collect sensor data.
-         
+        updateRestart(1,restartGroup);
         xEventGroupSetBits(manager_eg, MANAGER_STATUS_EVENT_BIT); // Indicate that the peripheral manager is running
 
         // Collect sensor data---add additional sensors here as needed
@@ -89,7 +91,6 @@ static void run_manager(void *arg)
 
         // Publish data
         publish_payload(fullness, weight, usage);
-
         xEventGroupClearBits(manager_eg, MANAGER_STATUS_EVENT_BIT); // Indicate that the peripheral manager is stopped
     }
 }

--- a/components/peripherals/peripheral_manager/restart.c
+++ b/components/peripherals/peripheral_manager/restart.c
@@ -1,34 +1,58 @@
 #include "esp_err.h"
 #include "esp_system.h"
- 
+#include "client_publish.hpp"
 
-#define restartFlag (1<<0);
-
-EventGroupHandle_t restartGroup;
-void restartTask(){
-
-}   
-/*
-add an ISR
-ISR sets the bit
-once the bit is check check if the restart flag is yes or no
-if it is yes
-call restart function and restart
-*/
-
-void updateRestart(void){
-    BaseType_t HigherPriorityTaskWoken;
-    HigherPriorityTaskWoken = pdFALSE;
-    xEventGroupSetBitsFromISR(
+#define systemFlag (1<<0);
+#define serverFlag (1<<0);
+EventGroupHandle_t restartGroup = xEventGroupCreate();
+void restartTask(EventGroupHandle_t restartGroup){
+    for(;;){
+    /*
+    This Waits for the restart to be sent by the server
+    */
+    xEventGroupWaitBits(
         restartGroup,
-        restartFlag,
-        &HigherPriorityTaskWoken
+        serverFlag,
+        pdTrue,
+        pdTrue,
+        portMAX_DELAY       
     );
-    portYIELD_FROM_ISR(HigherPriorityTaskWoken);
+    /*This waits for the system to be available*/
+    xEventGroupWaitBits(
+        restartGroup,
+        systemFlag,
+        pdTrue,
+        pdTrue,
+        portMAX_DELAY
+    );
+    restart();
+    }
+}   
 
+void updateRestart(int requirement,EventGroupHandle_t restartGroup){    
+    if(requirement == 0){
+    xEventGroupSetBits(
+        restartGroup,
+        systemFlag
+    );
+    }
+    elif(requirement == 1){
+    xEventGroupSetBits(
+        restartGroup,
+        systemFlag
+    );
+    }
 }
 
-esp_err_t restart(){    
-
+void restart(){
+    /*Send message to Server and Restart*/
+    client_publish("System is Restarting...");
+    esp_restart();
 }
 
+void receiveServer(EventGroupHandle_t restartGroup){
+    xEventGroupSetBits(
+        restartGroup,
+        serverFlag
+    );
+}

--- a/components/peripherals/peripheral_manager/restart.c
+++ b/components/peripherals/peripheral_manager/restart.c
@@ -1,11 +1,16 @@
+#include "freertos/FreeRTOS.h" 
+#include "freertos/event_groups.h"
 #include "esp_err.h"
 #include "esp_system.h"
 #include "client_publish.hpp"
+#include "restart.hpp"
 
-#define systemFlag (1<<0);
-#define serverFlag (1<<0);
-EventGroupHandle_t restartGroup = xEventGroupCreate();
+
+#define systemFlag (1<<0)
+#define serverFlag (1<<0)
+EventGroupHandle_t restartGroup;
 void restartTask(EventGroupHandle_t restartGroup){
+    restartGroup = xEventGroupCreate();
     for(;;){
     /*
     This Waits for the restart to be sent by the server
@@ -13,16 +18,16 @@ void restartTask(EventGroupHandle_t restartGroup){
     xEventGroupWaitBits(
         restartGroup,
         serverFlag,
-        pdTrue,
-        pdTrue,
+        pdTRUE,
+        pdTRUE,
         portMAX_DELAY       
     );
     /*This waits for the system to be available*/
     xEventGroupWaitBits(
         restartGroup,
         systemFlag,
-        pdTrue,
-        pdTrue,
+        pdTRUE,
+        pdTRUE,
         portMAX_DELAY
     );
     restart();
@@ -36,8 +41,8 @@ void updateRestart(int requirement,EventGroupHandle_t restartGroup){
         systemFlag
     );
     }
-    elif(requirement == 1){
-    xEventGroupSetBits(
+    else if(requirement == 1){
+    xEventGroupClearBits(
         restartGroup,
         systemFlag
     );
@@ -55,4 +60,4 @@ void receiveServer(EventGroupHandle_t restartGroup){
         restartGroup,
         serverFlag
     );
-}
+}   

--- a/components/peripherals/peripheral_manager/restart.c
+++ b/components/peripherals/peripheral_manager/restart.c
@@ -1,0 +1,34 @@
+#include "esp_err.h"
+#include "esp_system.h"
+ 
+
+#define restartFlag (1<<0);
+
+EventGroupHandle_t restartGroup;
+void restartTask(){
+
+}   
+/*
+add an ISR
+ISR sets the bit
+once the bit is check check if the restart flag is yes or no
+if it is yes
+call restart function and restart
+*/
+
+void updateRestart(void){
+    BaseType_t HigherPriorityTaskWoken;
+    HigherPriorityTaskWoken = pdFALSE;
+    xEventGroupSetBitsFromISR(
+        restartGroup,
+        restartFlag,
+        &HigherPriorityTaskWoken
+    );
+    portYIELD_FROM_ISR(HigherPriorityTaskWoken);
+
+}
+
+esp_err_t restart(){    
+
+}
+


### PR DESCRIPTION
Safe restart of ESP-32 through a server command. 
Checks if the ESP-32 is using any components, that could cause issues when restarted.
Sends a notice to the server that the ESP-32 is restarting